### PR TITLE
Enable support for multiple persistent pools

### DIFF
--- a/lib/Cake/Cache/Engine/MemcachedEngine.php
+++ b/lib/Cake/Cache/Engine/MemcachedEngine.php
@@ -110,7 +110,8 @@ class MemcachedEngine extends CacheEngine {
 		if (!$this->settings['persistent']) {
 			$this->_Memcached = new Memcached();
 		} else {
-			$this->_Memcached = new Memcached((string)$this->settings['persistent']);
+			$sPersistentId = implode(',', $this->settings['servers']); // life360 patch to allow for multiple addresses in persistent pool
+			$this->_Memcached = new Memcached($sPersistentId);
 		}
 		$this->_setOptions();
 


### PR DESCRIPTION
It has one constraint: each unique "servers" array creates a separate pool. Also, multiple "servers" in one array is untested.

This is a little hard to test on hb but worked on vm and will test on qa.
I will test on QA by using each individual node from the dev cluster in configs instead of the configuration endpoint, then check the outbound connections.

original: https://github.com/life360/cakephp/pull/2